### PR TITLE
Add MorphOne to supported relations

### DIFF
--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -5,6 +5,7 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 
 trait WithData
@@ -82,6 +83,13 @@ trait WithData
                     $other = $model->getQualifiedOwnerKeyName();
 
                     break;
+
+                case $model instanceof MorphOne:
+                    $table = $model->getRelated()->getTable();
+                    $foreign = $model->getQualifiedForeignKeyName();
+                    $other = $model->getQualifiedParentKeyName();
+
+                    break;                    
             }
 
             if ($table) {
@@ -131,7 +139,7 @@ trait WithData
         foreach ($column->getRelations() as $relationPart) {
             $model = $lastQuery->getRelation($relationPart);
 
-            if ($model instanceof HasOne || $model instanceof BelongsTo) {
+            if ($model instanceof HasOne || $model instanceof BelongsTo || $model instanceof MorphOne) {
                 $table = $model->getRelated()->getTable();
             }
 


### PR DESCRIPTION
I follow the guidelines in the Contributing document, but I can't show you a simple test because I wrote the patch directly in my web application.
Other people ask for this patch, but I cannot find a pull request about it.

I test the code in my pre-production web application, where I have polimorphic relations and I have to show it on the table.

I add support the MorphOne relations when use Column::make, for example:

  Column::make('Document ID', 'document.id');

create a column joining the document table; I use il on a Model having a MorphOne relation with Document Model.